### PR TITLE
Fix XDG_CONFIG_HOME path

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,2 +1,2 @@
-export XDG_CONFIG_HOME="{$HOME}/.config"
+export XDG_CONFIG_HOME="${HOME}/.config"
 export ZDOTDIR="${HOME}/.config/zsh"

--- a/bin/cfg_edit
+++ b/bin/cfg_edit
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 # This script changes directory to a programs config directory
 # and opens a file (usually the main config file) for that program
 # using the user's preferred editor
 
-if [[ $# != 1 ]]; then
-    echo "Too many arguments have been passed"
+if [ "$#" -ne 1 ]; then
+    echo "Usage: cfg_edit <nvim|zsh|tmux>"
     exit 1
 fi
 
@@ -29,7 +29,7 @@ case "$prog" in
         ;;
 esac
 
-cd $dir
-nvim $file
+cd "$dir"
+nvim "$file"
 
 exit 0


### PR DESCRIPTION
## Summary
- fix XDG_CONFIG_HOME expansion in `.zshenv`
- improve argument error message in `cfg_edit`
- use `/bin/sh` shebang for `cfg_edit`

## Testing
- `sh -n bin/cfg_edit`
- `source .zshenv && echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" && echo "ZDOTDIR=$ZDOTDIR"`


------
https://chatgpt.com/codex/tasks/task_e_688a40eb29ac832eb40efacd91830633